### PR TITLE
md: put "input.json" title onto code blocks

### DIFF
--- a/build/cheatsheet.md
+++ b/build/cheatsheet.md
@@ -68,7 +68,6 @@ Partial rules generate and assign a set of values to a variable. ([Try It](https
     ]
   }
 }
-
 ```
 <RunSnippet id="input.Partial+Rules.json"/>
 

--- a/build/cheatsheet.md
+++ b/build/cheatsheet.md
@@ -22,8 +22,7 @@ Complete rules assign a single value.
 
 
 
-Input:
-```json
+```json title="input.json"
 {
   "user": {
     "role": "admin",
@@ -60,8 +59,7 @@ Partial rules generate and assign a set of values to a variable. ([Try It](https
 
 
 
-Input:
-```json
+```json title="input.json"
 {
   "user": {
     "teams": [
@@ -127,8 +125,7 @@ Check conditions on many elements. ([Try It](https://play.openpolicyagent.org/?s
 
 
 
-Input:
-```json
+```json title="input.json"
 {
   "userID": "u123",
   "paths": [
@@ -164,8 +161,7 @@ Statements in rules are joined with logical AND. ([Try It](https://play.openpoli
 
 
 
-Input:
-```json
+```json title="input.json"
 {
   "email": "joe@example.com"
 }
@@ -193,8 +189,7 @@ Express OR with multiple rules, functions or the in keyword. ([Try It](https://p
 
 
 
-Input:
-```json
+```json title="input.json"
 {
   "email": "opa@example.com",
   "name": "anna",

--- a/main.go
+++ b/main.go
@@ -180,7 +180,11 @@ func main() {
 		panic(err)
 	}
 
-	mdTemplate, err := template.New("md").Parse(string(mdTemplateBs))
+	mdTemplate, err := template.New("md").
+		Funcs(template.FuncMap{
+			"trim": strings.TrimSpace,
+		}).
+		Parse(string(mdTemplateBs))
 	if err != nil {
 		panic(err)
 	}

--- a/templates/doc.md
+++ b/templates/doc.md
@@ -23,8 +23,7 @@ import rego.v1
 {{ end }}
 
 {{ if ne .Input "" }}
-Input:
-```json
+```json title="input.json"
 {{ .Input }}
 ```
 <RunSnippet id="input.{{.Title | urlquery}}.json"/>

--- a/templates/doc.md
+++ b/templates/doc.md
@@ -24,7 +24,7 @@ import rego.v1
 
 {{ if ne .Input "" }}
 ```json title="input.json"
-{{ .Input }}
+{{ .Input | trim }}
 ```
 <RunSnippet id="input.{{.Title | urlquery}}.json"/>
 {{ end }}


### PR DESCRIPTION
I think this looks nicer:

<img width="542" alt="image" src="https://github.com/user-attachments/assets/6ebada79-d51d-404c-ac20-e4e340d66d4e">
